### PR TITLE
Added PureComponent do docgenConverter and examples

### DIFF
--- a/examples/react-styleguidist-example/components/ConstExport.tsx
+++ b/examples/react-styleguidist-example/components/ConstExport.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+
+/**
+ * Row properties.
+ */
+export interface IRowProps {
+    /** prop1 description */
+    prop1?: string;
+    /** prop2 description */
+    prop2: number;
+    /**
+     * prop3 description
+     */
+    prop3: () => void;
+    /** prop4 description */
+    prop4: 'option1' | 'option2' | "option3";
+}
+
+/**
+ * test
+ * 
+ */
+export const test = (one: number) => {
+    return one;
+}
+
+export const myObj = {
+  foo: 'bar',
+}
+
+/**
+ * Form row.
+ */
+export const ConstExportRow = (props: IRowProps) => {
+    const innerFunc = (props: IRowProps) => {
+        return <span>Inner Func</span>
+    };
+    const innerNonExportedFunc = (props: IRowProps) => {
+        return <span>Inner Func</span>
+    };
+    return <div>Test</div>;
+};
+
+const nonExportedFunc = (props: IRowProps) => {
+    return <div>No Export</div>
+};
+
+export default ConstExportRow;

--- a/examples/react-styleguidist-example/components/PureRow.tsx
+++ b/examples/react-styleguidist-example/components/PureRow.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+
+/**
+ * Row properties.
+ */
+export interface IRowProps {
+    /** prop1 description */
+    prop1?: string;
+    /** prop2 description */
+    prop2: number;
+    /**
+     * prop3 description
+     */
+    prop3: () => void;
+    /** prop4 description */
+    prop4: 'option1' | 'option2' | "option3";
+}
+
+/**
+ * Form row.
+ */
+export class PureRow extends React.PureComponent<IRowProps, {}> {
+
+    render() {
+    return <div>Test</div>;
+    }
+};
+
+export default PureRow;

--- a/src/__tests__/docgenConverter.spec.ts
+++ b/src/__tests__/docgenConverter.spec.ts
@@ -99,4 +99,30 @@ describe('docgenConverter', () => {
         assert.equal('name1', result.displayName);
         assert.equal('comment1', result.description);
     });
+
+    it('Should work with class PureComponent', () => {
+        let result: StyleguidistComponent = null;
+        const originalWarn = console.warn;
+        let warnCallCount = 0;
+        console.warn = () => warnCallCount++;
+        try {
+            result = convertToDocgen({
+                classes: [
+                    { 
+                        name: 'name1',
+                        comment: 'comment1',
+                        extends: 'PureComponent',
+                        propInterface: null,
+                    }
+                ],
+                interfaces: []
+            });
+        } finally {
+            console.warn = originalWarn;
+        }
+
+        assert.equal(1, warnCallCount);
+        assert.equal('name1', result.displayName);
+        assert.equal('comment1', result.description);
+    });
 });

--- a/src/docgenConverter.ts
+++ b/src/docgenConverter.ts
@@ -11,7 +11,7 @@ export interface StyleguidistComponent {
 }
 
 export function convertToDocgen(doc: FileDoc): StyleguidistComponent {
-    const reactClasses = doc.classes.filter(i => i.extends === 'Component' || i.extends === 'StatelessComponent');
+    const reactClasses = doc.classes.filter(i => i.extends === 'Component' || i.extends === 'StatelessComponent' || i.extends === 'PureComponent');
 
     if (reactClasses.length === 0) {
         return null;


### PR DESCRIPTION
Missed to add `PureComponent` on docgenConverter.

Currently is not able to generate documentation with components that is extending from `PureComponent`